### PR TITLE
TASK: fix replace configuration in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		"phpunit/phpunit": "^4.7 || ^5.0"
 	},
 	"replace": {
-		"typo3-forum": "self.version",
+		"typo3_forum": "self.version",
 		"typo3-ter/typo3-forum": "self.version"
 	},
 	"config": {


### PR DESCRIPTION
Fixes the replace configuration in composer.json to install the extension to the correct folder typo3_forum with composer.

See #191 