### PR TITLE
TASK: use tsfe->gr_list to get usergroups instead of model method

### DIFF
--- a/Classes/Domain/Model/Forum/Access.php
+++ b/Classes/Domain/Model/Forum/Access.php
@@ -26,6 +26,7 @@ namespace Mittwald\Typo3Forum\Domain\Model\Forum;
 
 use Mittwald\Typo3Forum\Domain\Model\User\FrontendUser;
 use Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\DomainObject\AbstractValueObject;
 
 /**
@@ -94,6 +95,7 @@ class Access extends AbstractValueObject {
 	 * @var \Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup
 	 */
 	protected $affectedGroup;
+
 
 
 	public function __construct($operation = NULL, $level = NULL, \Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup $group = NULL) {
@@ -184,16 +186,16 @@ class Access extends AbstractValueObject {
 				throw new \Exception('access record #' . $this->getUid() . ' is of login level type "specific", but has not valid affected user group', 1436527735);
 			}
 			if ($user !== NULL) {
-				foreach ($user->getUsergroup() as $group) {
-					/** @var $group \Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup */
-					if ($group->getUid() === $this->affectedGroup->getUid()) {
+				$userGroupUids = GeneralUtility::trimExplode(',', $GLOBALS['TSFE']->gr_list);
+
+				foreach ($userGroupUids as $groupUid) {
+					if ((integer) $groupUid === $this->affectedGroup->getUid()) {
 						$result = TRUE;
 						break;
 					}
 				}
 			}
 		}
-
 		return $result;
 	}
 

--- a/Classes/Service/Authentication/AuthenticationService.php
+++ b/Classes/Service/Authentication/AuthenticationService.php
@@ -31,6 +31,8 @@ use Mittwald\Typo3Forum\Domain\Model\Forum\Forum;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Post;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
 use Mittwald\Typo3Forum\Service\AbstractService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
 
 /**
  * A service class that handles the entire authentication.
@@ -64,10 +66,20 @@ class AuthenticationService extends AbstractService implements AuthenticationSer
 	 */
 	private $userGroupIdentifier = NULL;
 
+	/**
+	 * @var TypoScriptFrontendController
+	 */
+	protected $typoScriptFrontendController;
+
+
+	public function __construct()
+	{
+		$this->typoScriptFrontendController = $GLOBALS['TSFE'];
+	}
+
 	/*
 	 * AUTHENTICATION METHODS
 	 */
-
 
 	/**
 	 * Asserts that the current user is authorized to read a specific object.
@@ -204,11 +216,8 @@ class AuthenticationService extends AbstractService implements AuthenticationSer
 			if ($user === NULL) {
 				$this->userGroupIdentifier = 'n';
 			} else {
-				$groupUids = [];
-				foreach ($user->getUsergroup() as $group) {
-					/** @var \Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup $group */
-					$groupUids[] = $group->getUid();
-				}
+				$groupUids = GeneralUtility::trimExplode(',', $this->typoScriptFrontendController->gr_list);
+
 				$this->userGroupIdentifier = implode('g', $groupUids);
 			}
 		}


### PR DESCRIPTION
When using services of the type "getGroupsFE" to extend the usergroups of a user dynamically (e.g. if he has a specific flag set), then these groups are not found within the model properties/methods, but they should be used when checking for access. 

By using $GLOBALS['TSFE']->gr_list instead of model functions to check the access the dynamic groups can be used.