### PR TITLE
TASK: improve performance

### DIFF
--- a/Classes/Configuration/ConfigurationBuilder.php
+++ b/Classes/Configuration/ConfigurationBuilder.php
@@ -1,0 +1,96 @@
+<?php
+namespace Mittwald\Typo3Forum\Configuration;
+
+/***************************************************************
+ *  Copyright (C) 2017 punkt.de GmbH
+ *  Authors: el_equipo <el_equipo@punkt.de>
+ *
+ *  This script is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published
+ *  by the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This script is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  This copyright notice MUST APPEAR in all copies of the script!
+ ***************************************************************/
+
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Service\TypoScriptService;
+
+class ConfigurationBuilder implements SingletonInterface {
+
+    /**
+     * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+     * @inject
+     *
+     */
+    protected $typoScriptService;
+
+    /**
+     * @var array
+     */
+    protected $settings = [];
+
+    /**
+     * @var array
+     */
+    protected $persistenceSettings = [];
+
+    /**
+     * @return array
+     */
+    public function getSettings()
+    {
+        if (!count($this->settings)) {
+            $this->loadTypoScript();
+        }
+
+        return $this->settings;
+    }
+
+
+    /**
+     * @return array
+     */
+    public function getPersistenceSettings()
+    {
+        if (!count($this->persistenceSettings)) {
+            $this->loadTypoScript();
+        }
+
+        return $this->persistenceSettings;
+    }
+
+
+    protected function loadTypoScript()
+    {
+        $typoScript = $this->getTypoScriptService()->convertTypoScriptArrayToPlainArray($GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_typo3forum.']);
+        $this->settings = $typoScript['settings'];
+        $this->persistenceSettings = $typoScript['persistence'];
+    }
+
+
+    /**
+     * this method is taken from the old implementation in AbstractRepository. The reason this exists is that if somehow the
+     * inject doesn't work, we still have a working TypoScriptService
+     *
+     * @return TypoScriptService
+     */
+    protected function getTypoScriptService()
+    {
+        if (is_null($this->typoScriptService)) {
+            $this->typoScriptService = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
+        }
+
+        return $this->typoScriptService;
+    }
+
+}

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -46,11 +46,12 @@ class AjaxController extends AbstractController {
 	 */
 	protected $forumRepository;
 
-	/**
-	 * @var \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
-	 * @inject
-	 */
-	protected $frontendConfigurationManager;
+
+    /**
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
+     * @inject
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * @var \Mittwald\Typo3Forum\Domain\Factory\Forum\PostFactory
@@ -77,29 +78,22 @@ class AjaxController extends AbstractController {
 	protected $topicRepository;
 
 	/**
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+	 * @var \Mittwald\Typo3Forum\Service\SessionHandlingService
 	 * @inject
 	 */
-	protected $typoScriptService = NULL;
+	protected $sessionHandlingService;
 
-    /**
-     * @var \Mittwald\Typo3Forum\Service\SessionHandlingService
-     * @inject
-     */
-    protected $sessionHandlingService;
-
-    /**
-     * @var \Mittwald\Typo3Forum\Service\AttachmentService
-     * @inject
-     */
-    protected $attachmentService = NULL;
+	/**
+	 * @var \Mittwald\Typo3Forum\Service\AttachmentService
+	 * @inject
+	 */
+	protected $attachmentService = NULL;
 
 	/**
 	 *
 	 */
 	public function initializeObject() {
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($this->frontendConfigurationManager->getTypoScriptSetup());
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	/**

--- a/Classes/Domain/Factory/AbstractFactory.php
+++ b/Classes/Domain/Factory/AbstractFactory.php
@@ -31,12 +31,6 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractDomainObject;
 abstract class AbstractFactory implements SingletonInterface {
 
 	/**
-	 * @var \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
-	 * @inject
-	 */
-	protected $frontendConfigurationManager;
-
-	/**
 	 * @var \Mittwald\Typo3Forum\Domain\Repository\User\FrontendUserRepository
 	 * @inject
 	 */
@@ -48,11 +42,11 @@ abstract class AbstractFactory implements SingletonInterface {
 	 */
 	protected $objectManager = NULL;
 
-	/**
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService = NULL;
+    /**
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
+     * @inject
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * Whole TypoScript typo3_forum settings
@@ -64,8 +58,7 @@ abstract class AbstractFactory implements SingletonInterface {
 	 *
 	 */
 	public function initializeObject() {
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($this->frontendConfigurationManager->getTypoScriptSetup());
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	/**

--- a/Classes/Domain/Model/Forum/Attachment.php
+++ b/Classes/Domain/Model/Forum/Attachment.php
@@ -63,11 +63,10 @@ class Attachment extends AbstractEntity {
 	protected $downloadCount;
 
 	/**
-	 * An instance of the typo3_forum authentication service.
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+	 * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
 	 * @inject
 	 */
-	protected $typoScriptService = NULL;
+	protected $configurationBuilder;
 
 	/**
 	 * Whole TypoScript typo3_forum settings
@@ -79,8 +78,7 @@ class Attachment extends AbstractEntity {
 	 * Injects an instance of the \TYPO3\CMS\Extbase\Service\TypoScriptService.
 	 */
 	public function initializeObject() {
-		$ts = $this->getTyposcriptService()->convertTypoScriptArrayToPlainArray($GLOBALS['TSFE']->tmpl->setup);
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	/**
@@ -230,15 +228,4 @@ class Attachment extends AbstractEntity {
         return $GLOBALS['TCA']['tx_typo3forum_domain_model_forum_attachment'];
     }
 
-    /**
-     * @return TypoScriptService
-     */
-    private function getTyposcriptService()
-    {
-        if (is_null($this->typoScriptService)) {
-           $this->typoScriptService = GeneralUtility::makeInstance('\\TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
-        }
-
-        return $this->typoScriptService;
-    }
 }

--- a/Classes/Domain/Model/Forum/Topic.php
+++ b/Classes/Domain/Model/Forum/Topic.php
@@ -24,6 +24,7 @@ namespace Mittwald\Typo3Forum\Domain\Model\Forum;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
+use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
 use Mittwald\Typo3Forum\Domain\Model\AccessibleInterface;
 use Mittwald\Typo3Forum\Domain\Model\NotifiableInterface;
 use Mittwald\Typo3Forum\Domain\Model\ReadableInterface;
@@ -174,12 +175,10 @@ class Topic extends AbstractEntity implements AccessibleInterface, Subscribeable
 	 */
 	protected $topicRepository;
 
-	/**
-	 * An instance of the typo3_forum authentication service.
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService = NULL;
+    /**
+     * @var ConfigurationBuilder
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * Whole TypoScript typo3_forum settings
@@ -187,17 +186,11 @@ class Topic extends AbstractEntity implements AccessibleInterface, Subscribeable
 	 */
 	protected $settings;
 
-	/**
-	 * Injects an instance of the \TYPO3\CMS\Extbase\Service\TypoScriptService.
-	 *
-	 * @param \TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService
-	 */
-	public function injectTyposcriptService(\TYPO3\CMS\Extbase\Service\TypoScriptService $typoScriptService) {
-		$this->typoScriptService = $typoScriptService;
-		$fc = new \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager;
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($fc->getTypoScriptSetup());
-
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+    /**
+     * @param ConfigurationBuilder $configurationBuilder
+     */
+	public function injectSettings(ConfigurationBuilder $configurationBuilder) {
+		$this->settings = $configurationBuilder->getSettings();
 	}
 
 	/**

--- a/Classes/Domain/Model/User/FrontendUser.php
+++ b/Classes/Domain/Model/User/FrontendUser.php
@@ -24,6 +24,7 @@ namespace Mittwald\Typo3Forum\Domain\Model\User;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
+use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
 use Mittwald\Typo3Forum\Domain\Model\AccessibleInterface;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Access;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Forum;
@@ -42,12 +43,6 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 	const GENDER_MALE = 0;
 	const GENDER_FEMALE = 1;
 	const GENDER_PRIVATE = 99;
-
-	/**
-	 * @var \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
-	 * @inject
-	 */
-	protected $frontendConfigurationManager;
 
 	/**
 	 * The rank repository
@@ -292,13 +287,14 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 	 */
 	protected $settings = NULL;
 
-	/**
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService;
+    /**
+     * @param ConfigurationBuilder $configurationBuilder
+     */
+    public function injectSettings(ConfigurationBuilder $configurationBuilder) {
+        $this->settings = $configurationBuilder->getSettings();
+    }
 
-	/**
+    /**
 	 * Constructor.
 	 *
 	 * @param string $username The user's username.
@@ -308,17 +304,6 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 		parent::__construct($username, $password);
 		$this->readTopics = new ObjectStorage();
 		$this->readForum = new ObjectStorage();
-	}
-
-	/**
-	 * @return array
-	 */
-	protected function getSettings() {
-		if ($this->settings === NULL) {
-			$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($this->frontendConfigurationManager->getTypoScriptSetup());
-			$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
-		}
-		return $this->settings;
 	}
 
 	/**
@@ -615,7 +600,7 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 	public function getImagePath() {
 
 		if ($this->image) {
-			$imageDirectoryName = $this->getSettings()['images']['avatar']['uploadDir'];
+			$imageDirectoryName = $this->settings['images']['avatar']['uploadDir'];
 			$imageFilename = rtrim($imageDirectoryName, '/') . '/' . $this->image;
 
 			return file_exists($imageFilename) ? $imageFilename : NULL;
@@ -638,10 +623,10 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 
 		switch ($this->gender) {
 			case self::GENDER_MALE:
-				$imageFilename = $this->getSettings()['images']['avatar']['dummyMale'];
+				$imageFilename = $this->settings['images']['avatar']['dummyMale'];
 				break;
 			case self::GENDER_FEMALE:
-				$imageFilename = $this->getSettings()['images']['avatar']['dummyFemale'];
+				$imageFilename = $this->settings['images']['avatar']['dummyFemale'];
 				break;
 		}
 

--- a/Classes/Domain/Repository/AbstractRepository.php
+++ b/Classes/Domain/Repository/AbstractRepository.php
@@ -50,11 +50,10 @@ abstract class AbstractRepository extends Repository
 {
 
     /**
-     * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
      * @inject
-     *
      */
-    protected $typoScriptService;
+    protected $configurationBuilder;
 
     /**
      * @var array
@@ -71,9 +70,8 @@ abstract class AbstractRepository extends Repository
      */
     public function initializeObject()
     {
-        $ts = $this->getTypoScriptService()->convertTypoScriptArrayToPlainArray($GLOBALS['TSFE']->tmpl->setup);
-        $this->settings = $ts['plugin']['tx_typo3forum']['settings'];
-        $this->persistenceSettings = $ts['plugin']['tx_typo3forum']['persistence'];
+        $this->settings = $this->configurationBuilder->getSettings();
+        $this->persistenceSettings = $this->configurationBuilder->getPersistenceSettings();
 
         if (isset($this->persistenceSettings['storagePid'])) {
             $this->setDefaultQuerySettings(
@@ -96,19 +94,6 @@ abstract class AbstractRepository extends Repository
         $query->getQuerySettings()->setStoragePageIds($storagePageIds);
 
         return $query;
-    }
-
-
-    /**
-     * @return TypoScriptService
-     */
-    protected function getTypoScriptService()
-    {
-        if (is_null($this->typoScriptService)) {
-            $this->typoScriptService = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Service\\TypoScriptService');
-        }
-
-        return $this->typoScriptService;
     }
 
     /**

--- a/Classes/Service/Mailing/AbstractMailingService.php
+++ b/Classes/Service/Mailing/AbstractMailingService.php
@@ -29,22 +29,16 @@ use Mittwald\Typo3Forum\Service\AbstractService;
 abstract class AbstractMailingService extends AbstractService implements MailingServiceInterface {
 
 	/**
-	 * @var \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
-	 * @inject
-	 */
-	protected $frontendConfigurationManager;
-
-	/**
 	 * Whole TypoScript typo3_forum settings
 	 * @var array
 	 */
 	protected $settings;
 
-	/**
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService = NULL;
+    /**
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
+     * @inject
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * HTML mail format.
@@ -63,8 +57,7 @@ abstract class AbstractMailingService extends AbstractService implements Mailing
 	protected $format = self::MAILING_FORMAT_HTML;
 
 	public function initializeObject() {
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($this->frontendConfigurationManager->getTypoScriptSetup());
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	/**

--- a/Classes/Service/Notification/NotificationService.php
+++ b/Classes/Service/Notification/NotificationService.php
@@ -35,12 +35,6 @@ use Mittwald\Typo3Forum\Utility\Localization;
 class NotificationService extends AbstractService implements NotificationServiceInterface {
 
 	/**
-	 * @var \TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager
-	 * @inject
-	 */
-	protected $frontendConfigurationManager;
-
-	/**
 	 * @var \Mittwald\Typo3Forum\Service\Mailing\HTMLMailingService
 	 * @inject
 	 */
@@ -52,11 +46,11 @@ class NotificationService extends AbstractService implements NotificationService
 	 */
 	protected $uriBuilder;
 
-	/**
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService = NULL;
+    /**
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
+     * @inject
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * Whole TypoScript typo3_forum settings
@@ -65,8 +59,7 @@ class NotificationService extends AbstractService implements NotificationService
 	protected $settings;
 
 	public function initializeObject() {
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray($this->frontendConfigurationManager->getTypoScriptSetup());
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	/**

--- a/Classes/ViewHelpers/Ext/UserLinkViewHelper.php
+++ b/Classes/ViewHelpers/Ext/UserLinkViewHelper.php
@@ -27,12 +27,11 @@ use TYPO3\CMS\Fluid\ViewHelpers\CObjectViewHelper;
 
 class UserLinkViewHelper extends CObjectViewHelper {
 
-	/**
-	 * An instance of the typo3_forum authentication service.
-	 * @var \TYPO3\CMS\Extbase\Service\TypoScriptService
-	 * @inject
-	 */
-	protected $typoScriptService = NULL;
+    /**
+     * @var \Mittwald\Typo3Forum\Configuration\ConfigurationBuilder
+     * @inject
+     */
+    protected $configurationBuilder;
 
 	/**
 	 * Whole TypoScript typo3_forum settings
@@ -49,8 +48,7 @@ class UserLinkViewHelper extends CObjectViewHelper {
 	protected $authenticationService = NULL;
 
 	public function initializeObject() {
-		$ts = $this->typoScriptService->convertTypoScriptArrayToPlainArray(\TYPO3\CMS\Extbase\Configuration\FrontendConfigurationManager::getTypoScriptSetup());
-		$this->settings = $ts['plugin']['tx_typo3forum']['settings'];
+		$this->settings = $this->configurationBuilder->getSettings();
 	}
 
 	public function initialize() {

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -69,7 +69,7 @@ CREATE TABLE tx_typo3forum_domain_model_forum_access (
   l18n_parent int(11) NOT NULL default '0',
   l18n_diffsource mediumblob NOT NULL,
   PRIMARY KEY (uid),
-  KEY parent (pid)
+  KEY parent (pid),
   KEY forum (forum)
 );
 

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -70,6 +70,7 @@ CREATE TABLE tx_typo3forum_domain_model_forum_access (
   l18n_diffsource mediumblob NOT NULL,
   PRIMARY KEY (uid),
   KEY parent (pid)
+  KEY forum (forum)
 );
 
 
@@ -132,7 +133,8 @@ CREATE TABLE tx_typo3forum_domain_model_forum_forum (
   l18n_parent int(11) NOT NULL default '0',
   l18n_diffsource mediumblob NOT NULL,
   PRIMARY KEY (uid),
-  KEY parent (pid)
+  KEY parent (pid),
+  KEY forum (forum)
 );
 
 
@@ -168,7 +170,9 @@ CREATE TABLE tx_typo3forum_domain_model_forum_post (
   supporters int(11) unsigned default '0',
   helpful_count int(11) unsigned NOT NULL default '0',
   PRIMARY KEY (uid),
-  KEY parent (pid)
+  KEY parent (pid),
+  KEY topic (topic),
+  KEY author (author)
 );
 
 
@@ -215,7 +219,9 @@ CREATE TABLE tx_typo3forum_domain_model_forum_topic (
   l18n_parent int(11) NOT NULL default '0',
   l18n_diffsource mediumblob NOT NULL,
   PRIMARY KEY (uid),
-  KEY parent (pid)
+  KEY parent (pid),
+  KEY forum (forum),
+  KEY author (author)
 );
 
 


### PR DESCRIPTION
- Add database keys for relations
- Load and parse typoscript only once via singleton
- use a common interface to load plugin configuration
- load and parse only typo3_forum typoscript, not the whole thing
- get rid of `new` (which led to multiple instances of typoscript parsing during the display of multiple topics)