### PR TITLE
fixes exception for CacheManager::deleteTemporaryFiles()

### DIFF
--- a/Classes/Cache/CacheManager.php
+++ b/Classes/Cache/CacheManager.php
@@ -51,6 +51,12 @@ class CacheManager {
 	protected function deleteTemporaryFiles() {
 		foreach ($this->fileCachePaths as $fileCachePath) {
 			$files = glob(PATH_site . $fileCachePath . '/*');
+
+			if(!is_array($files)) {
+				// skip
+				continue;
+			}
+
 			foreach ($files as $file) {
 				if (is_file($file)) {
 					unlink($file);


### PR DESCRIPTION
fixes exception for second foreach() if glob() returns false (happens if folder is empty)