### PR TITLE
Fixes topics DI in subscriber notifications

### DIFF
--- a/Classes/Domain/Model/ConfigurableInterface.php
+++ b/Classes/Domain/Model/ConfigurableInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Mittwald\Typo3Forum\Domain\Model;
+
+
+use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+
+interface ConfigurableInterface extends DomainObjectInterface
+{
+
+    /**
+     * @param ConfigurationBuilder $configurationBuilder
+     */
+    public function injectSettings(ConfigurationBuilder $configurationBuilder);
+
+}

--- a/Classes/Domain/Model/Forum/Topic.php
+++ b/Classes/Domain/Model/Forum/Topic.php
@@ -26,6 +26,7 @@ namespace Mittwald\Typo3Forum\Domain\Model\Forum;
 
 use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
 use Mittwald\Typo3Forum\Domain\Model\AccessibleInterface;
+use Mittwald\Typo3Forum\Domain\Model\ConfigurableInterface;
 use Mittwald\Typo3Forum\Domain\Model\NotifiableInterface;
 use Mittwald\Typo3Forum\Domain\Model\ReadableInterface;
 use Mittwald\Typo3Forum\Domain\Model\SubscribeableInterface;
@@ -38,7 +39,7 @@ use TYPO3\CMS\Extbase\DomainObject\AbstractEntity;
  * posts. Topic are submitted to the access control mechanism and
  * can be subscribed by users.
  */
-class Topic extends AbstractEntity implements AccessibleInterface, SubscribeableInterface, NotifiableInterface, ReadableInterface {
+class Topic extends AbstractEntity implements AccessibleInterface, SubscribeableInterface, NotifiableInterface, ReadableInterface, ConfigurableInterface {
 
 	/**
 	 * The subject

--- a/Classes/Domain/Model/User/FrontendUser.php
+++ b/Classes/Domain/Model/User/FrontendUser.php
@@ -26,6 +26,7 @@ namespace Mittwald\Typo3Forum\Domain\Model\User;
 
 use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
 use Mittwald\Typo3Forum\Domain\Model\AccessibleInterface;
+use Mittwald\Typo3Forum\Domain\Model\ConfigurableInterface;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Access;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Forum;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
@@ -38,7 +39,7 @@ use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 /**
  * A frontend user.
  */
-class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implements AccessibleInterface {
+class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implements AccessibleInterface, ConfigurableInterface {
 
 	const GENDER_MALE = 0;
 	const GENDER_FEMALE = 1;

--- a/Classes/Service/Notification/NotificationService.php
+++ b/Classes/Service/Notification/NotificationService.php
@@ -23,7 +23,6 @@ namespace Mittwald\Typo3Forum\Service\Notification;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
-use Mittwald\Typo3Forum\Domain\Model\Forum\Post;
 use Mittwald\Typo3Forum\Domain\Model\NotifiableInterface;
 use Mittwald\Typo3Forum\Domain\Model\SubscribeableInterface;
 use Mittwald\Typo3Forum\Service\AbstractService;
@@ -75,9 +74,7 @@ class NotificationService extends AbstractService implements NotificationService
 	 */
 	public function notifySubscribers(SubscribeableInterface $subscriptionObject, NotifiableInterface $notificationObject) {
 		$topic = $subscriptionObject;
-		/** @var Post $post */
 		$post  = $notificationObject;
-		$post->getTopic()->injectSettings($this->configurationBuilder);
 
 		$subject = Localization::translate('Mail_Subscribe_NewPost_Subject');
 		$messageTemplate = Localization::translate('Mail_Subscribe_NewPost_Body');

--- a/Classes/Service/Notification/NotificationService.php
+++ b/Classes/Service/Notification/NotificationService.php
@@ -23,6 +23,7 @@ namespace Mittwald\Typo3Forum\Service\Notification;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
+use Mittwald\Typo3Forum\Domain\Model\Forum\Post;
 use Mittwald\Typo3Forum\Domain\Model\NotifiableInterface;
 use Mittwald\Typo3Forum\Domain\Model\SubscribeableInterface;
 use Mittwald\Typo3Forum\Service\AbstractService;
@@ -74,7 +75,9 @@ class NotificationService extends AbstractService implements NotificationService
 	 */
 	public function notifySubscribers(SubscribeableInterface $subscriptionObject, NotifiableInterface $notificationObject) {
 		$topic = $subscriptionObject;
+		/** @var Post $post */
 		$post  = $notificationObject;
+		$post->getTopic()->injectSettings($this->configurationBuilder);
 
 		$subject = Localization::translate('Mail_Subscribe_NewPost_Subject');
 		$messageTemplate = Localization::translate('Mail_Subscribe_NewPost_Body');

--- a/Classes/Service/SettingsHydrator.php
+++ b/Classes/Service/SettingsHydrator.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Mittwald\Typo3Forum\Service;
+
+
+use Mittwald\Typo3Forum\Configuration\ConfigurationBuilder;
+use Mittwald\Typo3Forum\Domain\Model\ConfigurableInterface;
+use TYPO3\CMS\Extbase\DomainObject\DomainObjectInterface;
+use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
+
+class SettingsHydrator
+{
+    /**
+     * @var ConfigurationBuilder
+     */
+    private $configurationBuilder;
+
+    public function injectConfigurationBuilder(\Mittwald\Typo3Forum\Configuration\ConfigurationBuilder $configurationBuilder)
+    {
+        $this->configurationBuilder = $configurationBuilder;
+    }
+
+    public function hydrateSettings(DomainObjectInterface $object)
+    {
+        if ($object instanceof ConfigurableInterface) {
+            $object->injectSettings($this->configurationBuilder);
+        }
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -92,6 +92,7 @@ $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TY
 $signalSlotDispatcher->connect('Mittwald\Typo3Forum\Domain\Model\Forum\Post', 'postCreated', 'Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onPostCreated');
 $signalSlotDispatcher->connect('Mittwald\Typo3Forum\Domain\Model\Forum\Topic', 'topicCreated', 'Mittwald\Typo3Forum\Service\Notification\SubscriptionListener', 'onTopicCreated');
 $signalSlotDispatcher->connect('TYPO3\\CMS\\Extensionmanager\\Service\\ExtensionManagementService', 'hasInstalledExtensions', 'Mittwald\\Typo3Forum\\Service\\InstallService', 'checkForMigrationOption');
+$signalSlotDispatcher->connect('TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper', 'afterMappingSingleRow', 'Mittwald\Typo3Forum\Service\SettingsHydrator', 'hydrateSettings');
 
 // adding scheduler tasks
 


### PR DESCRIPTION
While creating a new post, settings are not injected into the current topic which leads to incorrect page number computation (division by 0).

This PR fixes the problem