### PR TITLE
BUGFIX: fix composer name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "mittwald/typo3-forum",
+	"name": "mittwald/typo3_forum",
 	"description": "Forum extension",
 	"license": "GPL-2",
 	"type": "typo3-cms-extension",


### PR DESCRIPTION
according to https://wiki.typo3.org/Composer packages of the type typo3-cms-extension
are installed to typo3conf/ext/{PackageName}. In typo3_forum the package name is
typo3-forum, thus it's installed to the wrong directory. By renaming the package name
the extension is put into the correct dir.