### PR TITLE
Fix attachment download

### DIFF
--- a/Classes/Controller/PostController.php
+++ b/Classes/Controller/PostController.php
@@ -354,10 +354,15 @@ class PostController extends AbstractController {
         $attachment->increaseDownloadCount();
 		$this->attachmentRepository->update($attachment);
 
+		//Enforce persistence, since it will not happen regularly because of die() at the end
+		$persistenceManager = $this->objectManager->get("TYPO3\\CMS\\Extbase\\Persistence\\Generic\\PersistenceManager");
+		$persistenceManager->persistAll();
+
         header('Content-type: ' . $attachment->getMimeType());
         header("Content-Type: application/download");
         header('Content-Disposition: attachment; filename="' . $attachment->getFilename() . '"');
 		readfile($attachment->getAbsoluteFilename());
+		die();
 	}
 
 }


### PR DESCRIPTION
At the moment some HTML code is attached to the download. So some files are corrupt and can't be opened afterwards. 

See: #230