### PR TITLE
Bugfix/v9 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: php
 php:
-- 5.5
-- 5.6
-- 7.0
+- 7.2
+- 7.3
 sudo: false
 script:
   - find Configuration Classes -name '*.php' | xargs -l1 php -l
@@ -17,4 +16,4 @@ deploy:
   on:
     repo: mittwald/typo3_forum
     tags: true
-    php: 5.6
+    php: 7.2

--- a/Classes/Ajax/Dispatcher.php
+++ b/Classes/Ajax/Dispatcher.php
@@ -25,14 +25,12 @@ namespace Mittwald\Typo3Forum\Ajax;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
+use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\TypoScript\ExtendedTemplateService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Extbase\Object\ObjectManager;
-use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
-use TYPO3\CMS\Frontend\Page\PageRepository;
-use TYPO3\CMS\Frontend\Utility\EidUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
 use TYPO3\CMS\Extbase\Core\Bootstrap;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Extbase\Object\ObjectManagerInterface;
 
 final class Dispatcher implements SingletonInterface
@@ -55,121 +53,99 @@ final class Dispatcher implements SingletonInterface
     private $objectManager = null;
 
     /**
+     * @var ConfigurationManagerInterface
+     */
+    private $configurationManager;
+
+    /**
      * Initialize the dispatcher.
      */
     private function init()
     {
-        $this->initializeTsfe();
-        $this->initTYPO3();
-        $this->initExtbase();
-    }
-
-    /**
-     * Initializes TSFE.
-     */
-    private function initializeTsfe()
-    {
-        $GLOBALS['TSFE'] = GeneralUtility::makeInstance(
-            TypoScriptFrontendController::class,
-            null,
-            GeneralUtility::_GP('id'),
-            GeneralUtility::_GP('type'),
-            true,
-            GeneralUtility::_GP('cHash')
-        );
-        $GLOBALS['TSFE']->initFEuser();
-        $GLOBALS['TSFE']->initUserGroups();
-        EidUtility::initTCA();
-        $GLOBALS['TSFE']->checkAlternativeIdMethods();
-        $GLOBALS['TSFE']->determineId();
-        $GLOBALS['TSFE']->sys_page = GeneralUtility::makeInstance(PageRepository::class);
-        $GLOBALS['TSFE']->initTemplate();
-        $GLOBALS['TSFE']->newCObj();
-    }
-
-    /**
-     * Initialize the global TSFE object.
-     *
-     * Most of the code was adapted from the df_tools extension by Stefan
-     * Galinski.
-     */
-    private function initTYPO3()
-    {
-        // The following code was adapted from the df_tools extension.
-        // Credits go to Stefan Galinski.
-        $GLOBALS['TSFE']->getPageAndRootline();
-        $GLOBALS['TSFE']->forceTemplateParsing = true;
-        $GLOBALS['TSFE']->no_cache = true;
-        $GLOBALS['TSFE']->tmpl->start($GLOBALS['TSFE']->rootLine);
-        $GLOBALS['TSFE']->no_cache = false;
-
-        $language = '';
-        if (isset($GLOBALS['TSFE']->tmpl->setup['config.']['language'])) {
-            $language = $GLOBALS['TSFE']->tmpl->setup['config.']['language'];
-        }
-        $sys_language_uid = 0;
-        if (isset($GLOBALS['TSFE']->tmpl->setup['config.']['sys_language_uid'])) {
-            $sys_language_uid = $GLOBALS['TSFE']->tmpl->setup['config.']['sys_language_uid'];
-        }
-        $linkVars = '';
-        if (isset($GLOBALS['TSFE']->tmpl->setup['config.']['linkVars'])) {
-            $linkVars = $GLOBALS['TSFE']->tmpl->setup['config.']['linkVars'];
-        }
-        $locale_all = '';
-        if (isset($GLOBALS['TSFE']->tmpl->setup['config.']['locale_all'])) {
-            $locale_all = $GLOBALS['TSFE']->tmpl->setup['config.']['locale_all'];
-        }
-
-        $GLOBALS['TSFE']->config = [];
-        $GLOBALS['TSFE']->config['config'] = [
-            'sys_language_mode' => 'content_fallback;0',
-            'sys_language_overlay' => 'hideNonTranslated',
-            'sys_language_softMergeIfNotBlank' => '',
-            'sys_language_softExclude' => '',
-            'language' => $language,
-            'sys_language_uid' => $sys_language_uid,
-            'linkVars' => $linkVars,
-            'locale_all' => $locale_all,
-        ];
-
-        $GLOBALS['TSFE']->settingLanguage();
-        $GLOBALS['TSFE']->settingLocale();
-        $GLOBALS['TSFE']->calculateLinkVars();
-    }
-
-    /**
-     * Initializes the Extbase framework by instantiating the bootstrap
-     * class and the extbase object manager.
-     *
-     * @return void
-     */
-    private function initExtbase()
-    {
-        $this->extbaseBootstap = GeneralUtility::makeInstance(Bootstrap::class);
-        $this->extbaseBootstap->initialize([
-            'extensionName' => $this->extensionKey,
-            'pluginName' => 'Ajax',
-            'vendorName' => 'Mittwald'
-        ]);
         $this->objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+        $this->configurationManager = $this->objectManager->get(ConfigurationManagerInterface::class);
+        $this->initTSFE(GeneralUtility::_GP('id'));
     }
 
     /**
-     * @param integer $pageUid
+     * @param int  $pageUid
+     * @param null $rootLine
+     * @param null $pageData
+     * @param null $rootlineFull
+     * @param null $sysLanguage
      */
-    private function loadTS($pageUid = 0)
+    public function initTSFE($pageUid, $rootLine = null, $pageData = null, $rootlineFull = null, $sysLanguage = null): void
     {
-        $sysPageObj = GeneralUtility::makeInstance(PageRepository::class);
+        static $cacheTSFE = [];
+        static $lastTsSetupPid = null;
 
-        $rootLine = $sysPageObj->getRootLine($pageUid);
+        // Fetch page if needed
+        if ($pageData === null) {
+            $sysPageObj = $this->objectManager->get(\TYPO3\CMS\Frontend\Page\PageRepository::class);
 
-        $typoscriptParser = GeneralUtility::makeInstance(ExtendedTemplateService::class);
-        $typoscriptParser->tt_track = 0;
-        $typoscriptParser->init();
-        $typoscriptParser->runThroughTemplates($rootLine);
-        $typoscriptParser->generateConfig();
+            $pageData = $sysPageObj->getPage_noCheck($pageUid);
+        }
 
-        return $typoscriptParser->setup;
+        // create time tracker if needed
+        if (empty($GLOBALS['TT'])) {
+            $GLOBALS['TT'] = new \TYPO3\CMS\Core\TimeTracker\TimeTracker(false);
+            $GLOBALS['TT']->start();
+        }
+
+        if ($rootLine === null) {
+            $sysPageObj = $this->objectManager->get(\TYPO3\CMS\Frontend\Page\PageRepository::class);
+            $rootLine   = $sysPageObj->getRootLine($pageUid);
+
+            // save full rootline, we need it in TSFE
+            $rootlineFull = $rootLine;
+        }
+
+        // Only setup tsfe if current instance must be changed
+        if ($lastTsSetupPid !== $pageUid) {
+
+            // Cache TSFE if possible to prevent reinit (is still slow but we need the TSFE)
+            if (empty($cacheTSFE[$pageUid])) {
+                $GLOBALS['TSFE']       = $this->objectManager->get(
+                    \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController::class,
+                    $GLOBALS['TYPO3_CONF_VARS'],
+                    $pageUid,
+                    0
+                );
+                $GLOBALS['TSFE']->cObj = $this->objectManager->get(\TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer::class);
+
+                $this->configurationManager->setContentObject($GLOBALS['TSFE']->cObj);
+
+                $TSObj           = $this->objectManager->get(\TYPO3\CMS\Core\TypoScript\ExtendedTemplateService::class);
+                $TSObj->tt_track = 0;
+                $TSObj->init();
+                $TSObj->runThroughTemplates($rootLine);
+                $TSObj->generateConfig();
+
+                $_GET['id'] = $pageUid;
+                $GLOBALS['TSFE']->initFEuser();
+                $GLOBALS['TSFE']->determineId();
+
+                if (empty($GLOBALS['TSFE']->tmpl)) {
+                    $GLOBALS['TSFE']->tmpl = new \stdClass();
+                }
+
+                $GLOBALS['TSFE']->tmpl->setup = $TSObj->setup;
+                $GLOBALS['TSFE']->initTemplate();
+                $GLOBALS['TSFE']->getConfigArray();
+
+                $GLOBALS['TSFE']->baseUrl = $GLOBALS['TSFE']->config['config']['baseURL'];
+
+                $cacheTSFE[$pageUid] = $GLOBALS['TSFE'];
+            }
+
+            $GLOBALS['TSFE'] = $cacheTSFE[$pageUid];
+
+            $lastTsSetupPid = $pageUid;
+        }
+
+        $GLOBALS['TSFE']->page       = $pageData;
+        $GLOBALS['TSFE']->rootLine   = $rootlineFull;
+        $GLOBALS['TSFE']->cObj->data = $pageData;
     }
 
     /*
@@ -182,19 +158,24 @@ final class Dispatcher implements SingletonInterface
     public function processRequest()
     {
         $this->init();
-        echo $this->dispatch();
+
+        return $this->dispatch();
     }
 
     /**
      * Dispatches a request.
-     * @return string
+     * @return \Psr\Http\Message\ResponseInterface
      */
-    public function dispatch()
+    public function dispatch(): \Psr\Http\Message\ResponseInterface
     {
-        return $this->extbaseBootstap->run('', [
+        $this->extbaseBootstap = $this->objectManager->get(Bootstrap::class);
+        $content               = $this->extbaseBootstap->run('', [
             'extensionName' => $this->extensionKey,
-            'pluginName' => 'Ajax',
-            'vendorName' => 'Mittwald'
+            'pluginName'    => 'Ajax',
+            'vendorName'    => 'Mittwald'
         ]);
+
+        /* @var HtmlResponse $response */
+        return $this->objectManager->get(HtmlResponse::class, $content);
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -60,31 +60,31 @@ $_EXTKEY = 'typo3_forum';
 );
 
 # TCE-Main hook for clearing all typo3_forum caches
-$TYPO3_CONF_VARS['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'Mittwald\Typo3Forum\Cache\CacheManager->clearAll';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['clearCachePostProc'][] = 'Mittwald\Typo3Forum\Cache\CacheManager->clearAll';
 
-if (!is_array($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main'])) {
-	$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main'] = [];
+if (!is_array($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main'])) {
+	$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main'] = [];
 }
 
 if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(TYPO3_version) < '4006000') {
-	if (!isset($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['frontend'])) {
-		$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['frontend'] = 't3lib_cache_frontend_VariableFrontend';
+	if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['frontend'])) {
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['frontend'] = 't3lib_cache_frontend_VariableFrontend';
 	}
-	if (!isset($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['backend'])) {
-		$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['backend'] = 't3lib_cache_backend_DbBackend';
+	if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['backend'])) {
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['backend'] = 't3lib_cache_backend_DbBackend';
 	}
-	if (!isset($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options'])) {
-		$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options'] = [];
+	if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options'])) {
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options'] = [];
 	}
-	if (!isset($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['cacheTable'])) {
-		$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['cacheTable'] = 'tx_typo3forum_cache';
+	if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['cacheTable'])) {
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['cacheTable'] = 'tx_typo3forum_cache';
 	}
-	if (!isset($TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['tagsTable'])) {
-		$TYPO3_CONF_VARS['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['tagsTable'] = 'tx_typo3forum_cache_tags';
+	if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['tagsTable'])) {
+		$GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['typo3forum_main']['options']['tagsTable'] = 'tx_typo3forum_cache_tags';
 	}
 }
 
-$TYPO3_CONF_VARS['FE']['eID_include']['typo3_forum'] = 'EXT:typo3_forum/Classes/Ajax/Dispatcher.php';
+$GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['typo3_forum'] = \Mittwald\Typo3Forum\Ajax\Dispatcher::class . '::processRequest';
 
 // Connect signals to slots. Some parts of extbase suck, but the signal-slot
 // pattern is really cool! :P


### PR DESCRIPTION
I replaced the old FE faking process with something that works. As I did not find any recommendation on how to exactly fake it with the HTTP middleware as [mentioned](https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.3/Deprecation-84965-VariousTypoScriptFrontendControllerMethods.html) (`just by setting up the "frontend" middleware stack`).