### PR TITLE
Add TS option to disable PURGE on creating topic

### DIFF
--- a/Classes/Controller/TopicController.php
+++ b/Classes/Controller/TopicController.php
@@ -256,9 +256,13 @@ class TopicController extends AbstractController {
 		// Notify potential listeners.
 		$this->signalSlotDispatcher->dispatch(Topic::class, 'topicCreated', ['topic' => $topic]);
 		$this->clearCacheForCurrentPage();
-		$uriBuilder = $this->controllerContext->getUriBuilder();
-		$uri = $uriBuilder->setTargetPageUid($this->settings['pids']['Forum'])->setArguments(['tx_typo3forum_pi1[forum]' => $forum->getUid(), 'tx_typo3forum_pi1[controller]' => 'Forum', 'tx_typo3forum_pi1[action]' => 'show'])->build();
-		$this->purgeUrl('http://' . $_SERVER['HTTP_HOST'] . '/' . $uri);
+
+		if ($this->settings['purgeCache']) {
+			$uriBuilder = $this->controllerContext->getUriBuilder();
+			$uri = $uriBuilder->setTargetPageUid($this->settings['pids']['Forum'])->setArguments(['tx_typo3forum_pi1[forum]' => $forum->getUid(), 'tx_typo3forum_pi1[controller]' => 'Forum', 'tx_typo3forum_pi1[action]' => 'show'])->build();
+			$this->purgeUrl('http://' . $_SERVER['HTTP_HOST'] . '/' . $uri);
+		}
+
 		// Redirect to single forum display view
 		$this->redirect('show', 'Forum', NULL, ['forum' => $forum]);
 	}

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -309,6 +309,9 @@ plugin.tx_typo3forum.settings {
         dateTimeFormat = d. m. Y, H:i
     }
 
+	# Use HTTP-"PURGE" to clear cache of a forum on creating a new topic - for use with a caching proxy like varnish
+	purgeCache = 1
+
     widgets {
         newestPosts.limit = 6
         questionPosts.limit = 6


### PR DESCRIPTION
Make sending a HTTP 'PURGE' request, which clears the cache for caching
proxies like varnish optional by adding a TypoScript option 'purgeCache'
which is enabled by default to keep the current behaviour. Currently a
PURGE request is only sent to a forum on creating a topic for it.