### PR TITLE
Do not pass settings to Partials

### DIFF
--- a/Resources/Private/Templates/Bootstrap/Ajax/PostSummary.html
+++ b/Resources/Private/Templates/Bootstrap/Ajax/PostSummary.html
@@ -1,2 +1,2 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
-<f:render partial="Ajax/PostSummary" arguments="{post : post, settings: settings, hiddenImage: hiddenImage}"/>
+<f:render partial="Ajax/PostSummary" arguments="{post : post, hiddenImage: hiddenImage}"/>

--- a/Resources/Private/Templates/Standard/Ajax/PostSummary.html
+++ b/Resources/Private/Templates/Standard/Ajax/PostSummary.html
@@ -1,2 +1,2 @@
 {namespace mmf=Mittwald\Typo3Forum\ViewHelpers}
-<f:render partial="Ajax/PostSummary" arguments="{post : post, settings: settings, hiddenImage: hiddenImage}"/>
+<f:render partial="Ajax/PostSummary" arguments="{post : post, hiddenImage: hiddenImage}"/>


### PR DESCRIPTION
Since TYPO3 6.1 (dc77ba679530634d4a6b520bf6317fa5caa83d6a) settings are
accessible in Partials without explicitly passing them as argument.