### PR TITLE
Fix calling AJAX when using Bootstrap template

### DIFF
--- a/Resources/Private/Partials/Bootstrap/AjaxURL.html
+++ b/Resources/Private/Partials/Bootstrap/AjaxURL.html
@@ -1,5 +1,5 @@
 <script>
     currentPageUid = "{f:cObject(typoscriptObjectPath: 'lib.pageUid')}";
-    typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'})}";
-    typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'})}";
+    typo3_forum_ajaxUrl = "{f:uri.action(action: 'main', controller: 'Ajax', arguments:{format:'json'}, additionalParams:{eID:'typo3_forum'}) -> f:format.htmlentitiesDecode()}";
+    typo3_forum_ajaxUrl_helpful = "{f:uri.action(action: '__typo3_forum_action__', controller: 'Post', arguments:{post:'__typo3_forum_post__'}, additionalParams:{eID:'__typo3_forum_eid__'}) -> f:format.htmlentitiesDecode()}";
 </script>


### PR DESCRIPTION
The AJAX urls in the Bootstrap templates contained `&amp;` instead of `&`
which lead to a Javascript error as the eID scripts were not called and
HTML of the page was returned instead.

This patch applies the solution from the Standard Template by using
htmlentitiesDecode() on the AJAX urls.