### PR TITLE
Fix displaying JSON in eID AJAX response when using Bootstrap template

### DIFF
--- a/Resources/Private/Templates/Bootstrap/Ajax/Main.json
+++ b/Resources/Private/Templates/Bootstrap/Ajax/Main.json
@@ -1,1 +1,1 @@
-{content}
+{content -> f:format.raw()}


### PR DESCRIPTION
The JSON content returned by eID AJAX calls in the Bootstrap templates
was displayed encoded as HTML which lead to the JSON not being parsed.

This patch applies the solution from the Standard Template by using
f:format.raw on the JSON content.