### PR TITLE
Fix changing forum of a topic in Backend

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
@@ -101,7 +101,6 @@ return [
 			'label' => $lllPath . 'posts',
 			'config' => [
 				'type' => 'inline',
-				'foreign_sortby' => 'uid',
 				'foreign_table' => 'tx_typo3forum_domain_model_forum_post',
 				'foreign_field' => 'topic',
 				'maxitems' => 9999,


### PR DESCRIPTION
Changing the forum of a topic which has posts in Backend failed (at
least on PostgreSQL) as due to the `uid` column being set as
`foreign_sortby` the TYPO3 RelationHandler tried to update the `uid` of
the post (!!). In order to circumvent this until RelationHandler is
fixed do not sort posts of a topic in backend.