### PR TITLE
Fix display of topics without solution in backend

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
@@ -157,7 +157,10 @@ return [
 				'renderType' => 'selectSingle',
 				'foreign_class' => '\Mittwald\Typo3Forum\Domain\Model\Forum\Post',
 				'foreign_table' => 'tx_typo3forum_domain_model_forum_post',
-				'maxitems' => 1
+				'maxitems' => 1,
+				'items' => [
+					['-', '0'],
+				],
 			],
 		],
 		'forum' => [


### PR DESCRIPTION
When editing a topic which does not have a solution yet display '-'
instead of 'Invalid value [0]'