### PR TITLE
Fix exception on deleting topic

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -26,7 +26,7 @@ $_EXTKEY = 'typo3_forum';
 		'Post' => 'new, create, edit, update, delete',
 		'User' => 'showMyProfile, dashboard, subscribe, favSubscribe, listFavorites, listNotifications, listTopics, listMessages, createMessage,listPosts',
 		'Report' => 'newUserReport, newPostReport, createUserReport, createPostReport',
-		'Moderation' => 'indexReport, updateTopic, updateUserReportStatus, updatePostReportStatus, newReportComment, createUserReportComment, createPostReportComment',
+		'Moderation' => 'indexReport, updateTopic, topicConformDelete, updateUserReportStatus, updatePostReportStatus, newReportComment, createUserReportComment, createPostReportComment',
 		'Tag' => 'list, show, new, create, listUserTags, newUserTag, deleteUserTag',
 	]
 );


### PR DESCRIPTION
On deleting a topic from moderation an exception '#1297933823: Object of
type Mittwald\Typo3Forum\Domain\Model\Forum\Topic with identity "X" not
found' was shown as the action was not marked as uncached. This patch
marks the topicConformDeleteAction() as uncached which fixes the issue.