### PR TITLE
Make ConfigurableEntityTrait::$settings protected

### DIFF
--- a/Classes/Domain/Model/ConfigurableEntityTrait.php
+++ b/Classes/Domain/Model/ConfigurableEntityTrait.php
@@ -46,7 +46,7 @@ trait ConfigurableEntityTrait
      * Whole TypoScript typo3_forum settings
      * @var array
      */
-    private $settings;
+	protected $settings;
 
     /**
      * @param ConfigurationBuilder $configurationBuilder


### PR DESCRIPTION
In order to be able to debug Typo3Forum\Domain\Model objects using
DebuggerUtility::var_dump() or <f:debug/> $settings must be set to
protected instead of private.