### PR TITLE
[FEATURE] Allow defining of classes for RootlineViewHelper items

### DIFF
--- a/Classes/ViewHelpers/Forum/RootlineViewHelper.php
+++ b/Classes/ViewHelpers/Forum/RootlineViewHelper.php
@@ -29,7 +29,7 @@ use TYPO3\CMS\Extbase\Mvc\Web\Routing\UriBuilder;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
- * ViewHelper that renders a big button.
+ * ViewHelper that renders a rootline as nav-pills or breadcrumb.
  */
 class RootlineViewHelper extends AbstractTagBasedViewHelper
 {
@@ -51,8 +51,11 @@ class RootlineViewHelper extends AbstractTagBasedViewHelper
     {
         parent::initializeArguments();
         $this->registerUniversalTagAttributes();
-        $this->registerArgument('rootline', 'array', 'array of rootline elements', true);
-        $this->registerArgument('reverse', 'boolean', '');
+        $this->registerArgument('rootline', 'array', 'Array of rootline elements', true);
+        $this->registerArgument('reverse', 'boolean', 'Reverse the order of the elements in the rootline');
+        $this->registerArgument('breadcrumb', 'boolean', 'Use bootstrap breadcrumb classes instead of nav-pills');
+        $this->registerArgument('forumicon', 'string', 'Class to use for the forum icon');
+        $this->registerArgument('topicicon', 'string', 'Class to use for the topic icon');
     }
 
     /**
@@ -72,62 +75,71 @@ class RootlineViewHelper extends AbstractTagBasedViewHelper
     {
 
         $rootline = $this->arguments['rootline'];
-        $reverse = $this->arguments['reverse'];
 
+        if ($this->arguments['reverse']) {
+			$rootline = array_reverse($rootline);
+			$currentNodeIndex = 0;
+        } else {
+			$currentNodeIndex = count($rootline) - 1;
+		}
 
-        if ($reverse) {
-            array_reverse($rootline);
-        }
-
-        $class = 'nav nav-pills nav-pills-condensed';
+        $class = $this->arguments['breadcrumb'] ? 'breadcrumb' : 'nav nav-pills nav-pills-condensed';
         if ($this->arguments['class']) {
             $class .= ' ' . $this->arguments['class'];
         }
         $this->tag->addAttribute('class', $class);
 
         $content = '';
-        foreach ($rootline as $element) {
-            $content .= $this->renderNavigationNode($element);
+        foreach ($rootline as $index => $element) {
+            $content .= $this->renderNavigationNode($element, $index === $currentNodeIndex);
         }
-        $content .= '';
 
         $this->tag->setContent($content);
         return $this->tag->render();
     }
 
-    /**
-     * renderNavigationNode
-     *
-     * @param $object
-     *
-     * @return string
-     */
-    protected function renderNavigationNode($object)
+	/**
+	 * renderNavigationNode
+	 *
+	 * @param $object
+	 *
+	 * @param bool $isCurrentNode
+	 * @return string
+	 */
+    protected function renderNavigationNode($object, bool $isCurrentNode)
     {
         $extensionName = 'typo3forum';
         $pluginName = 'pi1';
         if ($object instanceof \Mittwald\Typo3Forum\Domain\Model\Forum\Forum) {
             $controller = 'Forum';
             $arguments = ['forum' => $object];
-            $icon = 'iconset-22-folder';
+            $icon = $this->arguments['forumicon'];
         } else {
             $controller = 'Topic';
             $arguments = ['topic' => $object];
-            $icon = 'iconset-22-balloon';
+            $icon = $this->arguments['topicicon'];
         }
         $fullTitle = htmlspecialchars($object->getTitle());
         $limit = (int)$this->settings['cutBreadcrumbOnChar'];
         if ($limit == 0 || strlen($fullTitle) < $limit) {
             $title = $fullTitle;
         } else {
-            $title = substr($fullTitle, 0, $limit) . "...";
+            $title = substr($fullTitle, 0, $limit) . '...';
         }
 
         $uriBuilder = $this->getUriBuilder();
         $uri = $uriBuilder->reset()->setTargetPageUid((int)$this->settings['pids']['Forum'])
             ->uriFor('show', $arguments, $controller, $extensionName, $pluginName);
 
-        return '<li><a href="' . $uri . '" title="' . $fullTitle . '"><i class="' . $icon . '"></i>' . $title . '</a></li>';
+		if ($this->arguments['breadcrumb']) {
+			$liClass = ' class="breadcrumb-item' . ($isCurrentNode ? ' active' : '') . '"';
+		} else {
+			$liClass = '';
+		}
+
+		$icon = empty($icon) ? '' : '<i class="' . $icon . '"></i>';
+
+		return '<li' . $liClass . '><a href="' . $uri . '" title="' . $fullTitle . '">' . $icon . $title . '</a></li>';
     }
 
 

--- a/Resources/Private/Templates/Bootstrap/Forum/Show.html
+++ b/Resources/Private/Templates/Bootstrap/Forum/Show.html
@@ -6,7 +6,7 @@
 
 	<h2>{forum.title}</h2>
 
-	<mmf:forum.rootline rootline="{forum.rootline}" />
+	<mmf:forum.rootline rootline="{forum.rootline}" breadcrumb="1" forumicon="iconset-22-folder" topicicon="iconset-22-balloon" />
 
 	<f:if condition="{forum.children}">
 		<f:render partial="Forum/List" arguments="{category: forum, header: 'Subforums'}" />

--- a/Resources/Private/Templates/Bootstrap/Moderation/EditReport.html
+++ b/Resources/Private/Templates/Bootstrap/Moderation/EditReport.html
@@ -80,7 +80,8 @@
 						<f:translate key="Report_Edit_Topic" />
 					</div>
 					<div class="controls">
-						<mmf:forum.rootline rootline="{report.topic.rootline}" style="margin-bottommf: 0px;" />
+						<mmf:forum.rootline rootline="{report.topic.rootline}" breadcrumb="1" forumicon="iconset-22-folder" topicicon="iconset-22-balloon"
+											class="mb-0"/>
 					</div>
 				</div>
 				<f:render partial="Post/Single" arguments="{post: report.post}" />

--- a/Resources/Private/Templates/Bootstrap/Topic/Show.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/Show.html
@@ -8,7 +8,7 @@
 
 	<h2 class="topic_entry" data-uid="{topic.uid}">{topic.subject}</h2>
 
-	<mmf:forum.rootline rootline="{topic.rootline}" />
+	<mmf:forum.rootline rootline="{topic.rootline}" breadcrumb="1" forumicon="iconset-22-folder" topicicon="iconset-22-balloon" />
 
 	<f:widget.paginate objects="{posts}" as="paginatedPosts" configuration="{settings.topicController.show.pagebrowser}">
 		<f:for each="{paginatedPosts}" as="post">

--- a/Resources/Private/Templates/Standard/Forum/Show.html
+++ b/Resources/Private/Templates/Standard/Forum/Show.html
@@ -8,7 +8,7 @@
 
 	<h2>{forum.title}</h2>
 
-	<mmf:forum.rootline rootline="{forum.rootline}" />
+	<mmf:forum.rootline rootline="{forum.rootline}" forumicon="iconset-22-folder" topicicon="iconset-22-balloon" />
 
 	<f:if condition="{forum.children}">
 		<f:render partial="Forum/List" arguments="{category: forum, header: 'Subforums'}" />

--- a/Resources/Private/Templates/Standard/Moderation/EditReport.html
+++ b/Resources/Private/Templates/Standard/Moderation/EditReport.html
@@ -80,7 +80,8 @@
 						<f:translate key="Report_Edit_Topic" />
 					</div>
 					<div>
-						<mmf:forum.rootline rootline="{report.topic.rootline}" style="margin-bottommf: 0px;" />
+						<mmf:forum.rootline rootline="{report.topic.rootline}" forumicon="iconset-22-folder" topicicon="iconset-22-balloon"
+											style="margin-bottom: 0px;"/>
 					</div>
 				</div>
 				<f:render partial="Post/Single" arguments="{post: report.post}" />

--- a/Resources/Private/Templates/Standard/Topic/Show.html
+++ b/Resources/Private/Templates/Standard/Topic/Show.html
@@ -2,7 +2,7 @@
 <f:layout name="default" />
 <f:section name="main">
 	<h2 class="topic_entry" data-uid="{topic.uid}">{topic.subject}</h2>
-	<mmf:forum.rootline rootline="{topic.rootline}" />
+	<mmf:forum.rootline rootline="{topic.rootline}" forumicon="iconset-22-folder" topicicon="iconset-22-balloon" />
 	<f:widget.paginate objects="{posts}" as="paginatedPosts" configuration="{settings.topicController.show.pagebrowser}">
 		<f:for each="{paginatedPosts}" as="post">
 			<f:render partial="Post/Single" arguments="{post: post}" />


### PR DESCRIPTION
This patch allows to define classes for the icons of forum and topic in
the rootline (omitting the icons completely if not set) and allows to
use breadcrumb instead of nav-pills (which is configured as default for
the bootstrap templates).

This patch also fixes the "reverse" attribute, which did not work yet.