### PR TITLE
Improve fe_groups.user_mod usage

### DIFF
--- a/Classes/Domain/Model/User/FrontendUser.php
+++ b/Classes/Domain/Model/User/FrontendUser.php
@@ -32,7 +32,6 @@ use Mittwald\Typo3Forum\Domain\Model\Forum\Forum;
 use Mittwald\Typo3Forum\Domain\Model\Forum\Topic;
 use Mittwald\Typo3Forum\Domain\Model\ReadableInterface;
 use Mittwald\Typo3Forum\Domain\Model\SubscribeableInterface;
-use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Persistence\ObjectStorage;
 
@@ -488,16 +487,13 @@ class FrontendUser extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUser implemen
 	 * @return boolean
 	 */
 	public function checkAccess(FrontendUser $user = NULL, $accessType = Access::TYPE_MODERATE) {
-		// @todo: the $accessType and the switch statement are useless here
-		switch ($accessType) {
-			default:
-				foreach ($user->getUsergroup() as $group) {
-					if ($group->getUserMod()) {
-						return TRUE;
-					}
-				}
-				return FALSE;
+		foreach ($user->getUsergroup() as $group) {
+			if ($group->getUserMod()) {
+				return TRUE;
+			}
 		}
+
+		return FALSE;
 	}
 
 	/**

--- a/Classes/Domain/Model/User/FrontendUserGroup.php
+++ b/Classes/Domain/Model/User/FrontendUserGroup.php
@@ -30,14 +30,16 @@ namespace Mittwald\Typo3Forum\Domain\Model\User;
 class FrontendUserGroup extends \TYPO3\CMS\Extbase\Domain\Model\FrontendUserGroup {
 
 	/**
-	 * Read topics.
-	 * @var integer
+	 * Status whether all users of this group have moderation permission
+	 *
+	 * @var int
 	 */
 	protected $userMod;
 
 	/**
-	 * Gets the post count of this user.
-	 * @return integer
+	 * Gets the status whether all users of this group have moderation permission
+	 *
+	 * @return int
 	 */
 	public function getUserMod() {
 		return (int) $this->userMod;

--- a/Configuration/TCA/Overrides/fe_groups.php
+++ b/Configuration/TCA/Overrides/fe_groups.php
@@ -2,13 +2,13 @@
 
 $tempColumns = [
 	'tx_typo3forum_user_mod' => [
-		'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:fe_users.user_mod',
+		'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:fe_groups.user_mod',
 		'config' => [
 			'type' => 'check',
 		],
 	],
 ];
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_groups', $tempColumns, 1);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_groups', $tempColumns);
 $GLOBALS['TCA']['fe_groups']['types']['Mittwald\Typo3Forum\Domain\Model\User\FrontendUserGroup'] = $GLOBALS['TCA']['fe_groups']['types']['0'];
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTcaSelectItem(
 	'fe_groups',

--- a/Configuration/TCA/Overrides/fe_users.php
+++ b/Configuration/TCA/Overrides/fe_users.php
@@ -246,7 +246,7 @@ $tempColumns = [
 		],
 	],
 ];
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', $tempColumns, 1);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('fe_users', $tempColumns);
 
 $GLOBALS['TCA']['fe_users']['types']['Mittwald\Typo3Forum\Domain\Model\User\FrontendUser'] = $GLOBALS['TCA']['fe_users']['types']['0'];
 

--- a/Resources/Private/Language/locallang_db.xml
+++ b/Resources/Private/Language/locallang_db.xml
@@ -182,7 +182,6 @@
 			<label index="tx_typo3forum_domain_model_moderation_reportworkflowstatus.icon">Icon</label>
 			<label index="tx_typo3forum_domain_model_moderation_report.type">Type</label>
 
-			<label index="fe_users.user_mod">User mod</label>
 			<label index="fe_users.use_gravatar">Use gravatar image (if no local image)</label>
 			<label index="fe_users.contact">Contact addresses and social network profiles (JSON encoded)</label>
 			<label index="fe_users.tx_extbase_type.typo3_forum">typo3_forum user</label>
@@ -211,7 +210,9 @@
 			<label index="fe_users.tx_typo3forum_domain_model_user_pm">Private messages</label>
 			<label index="fe_users.tx_typo3forum_points">Points</label>
 
+			<label index="fe_groups.user_mod">All members have moderation permission</label>
 			<label index="fe_groups.tx_extbase_type.typo3_forum">typo3_forum group</label>
+
 			<label index="backend.update.user_pid">Where are fe_users and fe_groups for usage of forum located?</label>
 			<label index="backend.update.run">Update database!</label>
 		</languageKey>


### PR DESCRIPTION
This patch renames and improves the label for fe_groups.user_mod,
improves the according PHPDoc and removes the no longer valid third
parameter to addTCAcolumns()