### PR TITLE
Unified dateFormat and dateTimeFormat usage

### DIFF
--- a/Resources/Private/Partials/Bootstrap/User/InformationRow.html
+++ b/Resources/Private/Partials/Bootstrap/User/InformationRow.html
@@ -8,6 +8,6 @@
 					   pageUid="{settings.pids.UserShow}">{user.username}</f:link.action>
 	</div>
 	<mmf:user.avatar user="{user}" width="64" alt="{user.username}" />
-	<div><f:translate key="User_Show_MemberSince" /> <f:format.date format="d. m. Y">{user.timestamp}</f:format.date></div>
+	<div><f:translate key="User_Show_MemberSince" /> <f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date></div>
 	<div><f:translate key="User_Show_PostCount" arguments="{0: user.postCount}" /></div>
 </div>

--- a/Resources/Private/Partials/Bootstrap/User/List.html
+++ b/Resources/Private/Partials/Bootstrap/User/List.html
@@ -32,7 +32,7 @@
 					<td>
 						<mmf:user.link user="{user}"/></td>
 					<td>
-						<f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+						<f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
 					</td>
 					<td>{user.postCount}</td>
 					<td>{user.helpfulCount}</td>

--- a/Resources/Private/Partials/Bootstrap/User/ListTopUser.html
+++ b/Resources/Private/Partials/Bootstrap/User/ListTopUser.html
@@ -25,7 +25,7 @@
 			<td>
 				<mmf:user.link user="{user}"/></td>
 			<td>
-				<f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+				<f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
 			</td>
 			<td>{user.rank.name}</td>
 			<td>{user.points}</td>

--- a/Resources/Private/Partials/Standard/User/InformationRow.html
+++ b/Resources/Private/Partials/Standard/User/InformationRow.html
@@ -9,6 +9,6 @@
 					   class="tx-typo3forum-topic-show-post-user-link"
 					   pageUid="{settings.pids.UserShow}">{user.username}</f:link.action>
 	</div>
-	<div><f:translate key="User_Show_MemberSince" /> <f:format.date format="d. m. Y">{user.timestamp}</f:format.date></div>
+	<div><f:translate key="User_Show_MemberSince" /> <f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date></div>
 	<div><f:translate key="User_Show_PostCount" arguments="{0: user.postCount}" /></div>
 </div>

--- a/Resources/Private/Partials/Standard/User/List.html
+++ b/Resources/Private/Partials/Standard/User/List.html
@@ -33,7 +33,7 @@
                     <mmf:user.link user="{user}"/>
                 </td>
                 <td>
-                    <f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+                    <f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
                 </td>
                 <td>{user.postCount}</td>
                 <td>{user.helpfulCount}</td>

--- a/Resources/Private/Partials/Standard/User/ListTopUser.html
+++ b/Resources/Private/Partials/Standard/User/ListTopUser.html
@@ -26,7 +26,7 @@
                 <mmf:user.link user="{user}"/>
             </td>
             <td>
-                <f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+                <f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
             </td>
             <td>{user.rank.name}</td>
             <td>{user.points}</td>

--- a/Resources/Private/Templates/Bootstrap/User/Index.html
+++ b/Resources/Private/Templates/Bootstrap/User/Index.html
@@ -37,7 +37,7 @@
 						<f:link.action controller="User" action="show" arguments="{user: user}" pageUid="{settings.pids.UserShow}">{user.username}</f:link.action>
 					</td>
 					<td>
-						<f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+						<f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
 					</td>
 					<td>{user.postCount}</td>
 					<td>

--- a/Resources/Private/Templates/Standard/User/Index.html
+++ b/Resources/Private/Templates/Standard/User/Index.html
@@ -33,7 +33,7 @@
                         </f:link.action>
                     </td>
                     <td>
-                        <f:format.date format="d. m. Y">{user.timestamp}</f:format.date>
+                        <f:format.date format="{settings.format.dateFormat}">{user.timestamp}</f:format.date>
                     </td>
                     <td>{user.postCount}</td>
                     <td>


### PR DESCRIPTION
Several templates did not use the `dateFormat` and `dateTimeFormat`
settings from TypoScript but defined the format themselves. This patch
unifies the usage by using the TypoScript settings everywhere.