### PR TITLE
[BUGFIX] Respect fe_groups.user_mod in Post->checkEditOrDeletePostAccess()

### DIFF
--- a/Classes/Domain/Model/Forum/Post.php
+++ b/Classes/Domain/Model/Forum/Post.php
@@ -279,6 +279,10 @@ class Post extends AbstractEntity implements AccessibleInterface, NotifiableInte
 		if ($user === NULL || $user->isAnonymous()) {
 			return FALSE;
 		} else {
+			if ($user->checkAccess($user, Access::TYPE_MODERATE)) {
+				return TRUE;
+			}
+
 			if ($this->getForum()->checkModerationAccess($user)) {
 				return TRUE;
 			}


### PR DESCRIPTION
When checking for moderation permissions in a post the check for the
"moderators" usergroup defined by `fe_groups.user_mod` was forgotten.
This patch adds the check allowing members of such a group to edit and
delete posts from the Topic->showAction().