### PR TITLE
[FEATURE] Allow optional inline display of posted image attachments

### DIFF
--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -38,5 +38,7 @@ plugin.tx_typo3forum {
         useSqlStatementsOnCriticalFunctions = 1
         # cat=typo3_forum: config/110/200; type=boolean; label= Use default css
         useDefaultCSS = 1
+        # cat=typo3_forum: config/110/210; type=boolean; label=Show images in posts inline (Views will not be counted)
+		showPostImagesInline = 0
     }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -247,6 +247,7 @@ plugin.tx_typo3forum.settings {
                 iconClass = iconset-22-helpful
                 eID = typo3_forum
             }
+			showImagesInline = {$plugin.tx_typo3forum.settings.showPostImagesInline}
         }
     }
 

--- a/Resources/Private/Partials/Bootstrap/Post/Single.html
+++ b/Resources/Private/Partials/Bootstrap/Post/Single.html
@@ -18,7 +18,13 @@
 									<div class="row">
 										<div class="col">
 											<f:link.action controller="Post" action="downloadAttachment" arguments="{attachment: attachment}">
-												{attachment.filename}
+												<f:if condition="{settings.forum.post.showImagesInline} && ({attachment.mimetype} == 'image/jpeg' || {attachment.mimetype} == 'image/png')">
+													<f:then>
+														<f:image src="{attachment.absoluteFilename}" alt="{attachment.filename}" class="img-fluid"
+																 title="{attachment.filename}"/>
+													</f:then>
+													<f:else>{attachment.filename}</f:else>
+												</f:if>
 											</f:link.action>
 										</div>
 									</div>

--- a/Resources/Private/Partials/Standard/Post/Single.html
+++ b/Resources/Private/Partials/Standard/Post/Single.html
@@ -27,10 +27,15 @@
                     <f:for each="{post.attachments}" as="attachment">
                         <tr>
                             <td>
-                                <f:link.action controller="Post" action="downloadAttachment"
-                                               arguments="{attachment: attachment}">
-                                    {attachment.filename}
-                                </f:link.action>
+                                <f:link.action controller="Post" action="downloadAttachment" arguments="{attachment: attachment}">
+									<f:if condition="{settings.forum.post.showImagesInline} && ({attachment.mimetype} == 'image/jpeg' || {attachment.mimetype} == 'image/png')">
+										<f:then>
+											<f:image src="{attachment.absoluteFilename}" alt="{attachment.filename}" style="max-width: 100%; height: auto;"
+													 title="{attachment.filename}"/>
+										</f:then>
+										<f:else>{attachment.filename}</f:else>
+									</f:if>
+								</f:link.action>
                             </td>
                             <td>{attachment.mimeType}</td>
                             <td>


### PR DESCRIPTION
This patch makes it possible to show posted image attachments (png,jpg)
by setting the TypoScript constant
`plugin.tx_typo3forum.settings.showPostImagesInline = 1`
Views of the post will not increase the download counter for the
attachment.