### PR TITLE
[FEATURE] Allow granular permissions for Forum, Post and Topic

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_forum.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_forum.php
@@ -19,10 +19,10 @@ return [
 		'iconfile' => 'EXT:typo3_forum/Resources/Public/Icons/Forum/Forum.png',
 	],
 	'interface' => [
-		'showRecordFieldList' => 'title,description,children,acls,criteria,last_topic,last_post,displayed_pid',
+		'showRecordFieldList' => 'hidden,title,description,children,acls,criteria,topics,topic_count,post_count,last_topic,last_post,forum,subscribers,readers,displayed_pid',
 	],
 	'types' => [
-		'1' => ['showitem' => 'title,description,children,acls,criteria'],
+		'1' => ['showitem' => 'hidden,title,description,children,acls,criteria,topics,last_topic,last_post,forum,subscribers,readers'],
 	],
     'palettes' => [
         'language' => ['showitem' => 'sys_language_uid, l18n_parent'],
@@ -103,6 +103,7 @@ return [
 			],
 		],
 		'children' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.children',
 			'config' => [
 				'type' => 'inline',
@@ -117,6 +118,7 @@ return [
 			]
 		],
 		'topics' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.topics',
 			'config' => [
 				'type' => 'inline',
@@ -130,6 +132,7 @@ return [
 			]
 		],
 		'criteria' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_criteria',
 			'config' => [
 				'type' => 'select',
@@ -153,6 +156,7 @@ return [
 			]
 		],
 		'acls' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.acls',
 			'config' => [
 				'type' => 'inline',
@@ -166,6 +170,7 @@ return [
 			]
 		],
 		'last_topic' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.last_topic',
 			'config' => [
 				'type' => 'none',
@@ -175,6 +180,7 @@ return [
 			]
 		],
 		'last_post' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.last_post',
 			'config' => [
 				'type' => 'none',
@@ -184,15 +190,20 @@ return [
 			]
 		],
 		'forum' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.forum',
 			'config' => [
 				'type' => 'select',
 				'renderType' => 'selectSingle',
 				'foreign_table' => 'tx_typo3forum_domain_model_forum_forum',
+				'items' => [
+					['-', 0],
+				],
 				'maxitems' => 1
 			]
 		],
 		'subscribers' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.subscribers',
 			'config' => [
 				'type' => 'inline',
@@ -204,6 +215,7 @@ return [
 			]
 		],
 		'readers' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_forum.readers',
 			'config' => [
 				'type' => 'inline',

--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_post.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_post.php
@@ -16,10 +16,10 @@ return [
 		'iconfile' => 'EXT:typo3_forum/Resources/Public/Icons/Forum/Post.png'
 	],
 	'interface' => [
-		'showRecordFieldList' => 'text,author,topic,attachments, helpful_count, supporters'
+		'showRecordFieldList' => 'hidden,text,author,author_name,topic,attachments,helpful_count,supporters'
 	],
 	'types' => [
-		'1' => ['showitem' => 'text,author,topic,attachments, helpful_count, supporters'],
+		'1' => ['showitem' => 'hidden,text,author,author_name,topic,attachments,helpful_count,supporters'],
 	],
 	'columns' => [
         'sys_language_uid' => [
@@ -115,12 +115,14 @@ return [
 			],
 		],
 		'helpful_count' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_post.helpful_count',
 			'config' => [
 				'type' => 'none'
 			],
 		],
 		'supporters' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.supporters',
 			'config' => [
 				'type' => 'select',

--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_topic.php
@@ -17,11 +17,12 @@ return [
 		'iconfile' => 'EXT:typo3_forum/Resources/Public/Icons/Forum/Topic.png'
 	],
 	'interface' => [
-		'showRecordFieldList' => 'type,subject,posts,author,subscribers,last_post,forum,target,question,criteria_options,solution,fav_subscribers,tags'
+		'showRecordFieldList' => 'hidden,type,subject,posts,post_count,author,last_post,last_post_crdate,forum,target,question,solution,closed,sticky'
+			.',criteria_options,tags,subscribers,fav_subscribers,readers'
 	],
 	'types' => [
-		'0' => ['showitem' => 'type,subject,posts,author,subscribers,last_post,forum,readers,question,solution,fav_subscribers,tags'],
-		'1' => ['showitem' => 'type,subject,forum,last_post,target'],
+		'0' => ['showitem' => 'hidden,type,subject,posts,author,last_post,forum,readers,question,solution,closed,sticky,criteria_options,tags,subscribers,fav_subscribers,readers'],
+		'1' => ['showitem' => 'hidden,type,subject,forum,last_post,target'],
 	],
 	'columns' => [
         'sys_language_uid' => [
@@ -91,6 +92,7 @@ return [
 			],
 		],
 		'posts' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.posts',
 			'config' => [
 				'type' => 'inline',
@@ -111,6 +113,7 @@ return [
 			],
 		],
 		'author' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.author',
 			'config' => [
 				'type' => 'select',
@@ -120,6 +123,7 @@ return [
 			],
 		],
 		'last_post' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.last_post',
 			'config' => [
 				'type' => 'select',
@@ -142,6 +146,7 @@ return [
 			],
 		],
 		'solution' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.solution',
 			'config' => [
 				'type' => 'select',
@@ -163,24 +168,28 @@ return [
 			],
 		],
 		'closed' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.closed',
 			'config' => [
 				'type' => 'check'
 			],
 		],
 		'sticky' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.sticky',
 			'config' => [
 				'type' => 'check'
 			],
 		],
 		'question' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.question',
 			'config' => [
 				'type' => 'check'
 			],
 		],
 		'criteria_options' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_criteria_options',
 			'config' => [
 				'type' => 'select',
@@ -192,6 +201,7 @@ return [
 			],
 		],
 		'tags' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.tags',
 			'config' => [
 				'type' => 'select',
@@ -203,6 +213,7 @@ return [
 			],
 		],
 		'subscribers' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.subscribers',
 			'config' => [
 				'type' => 'select',
@@ -215,6 +226,7 @@ return [
 			],
 		],
 		'fav_subscribers' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.fav_subscribers',
 			'config' => [
 				'type' => 'select',
@@ -227,6 +239,7 @@ return [
 			],
 		],
 		'target' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.target',
 			'config' => [
 				'type' => 'select',
@@ -237,6 +250,7 @@ return [
 			],
 		],
 		'readers' => [
+			'exclude' => 1,
 			'label' => 'LLL:EXT:typo3_forum/Resources/Private/Language/locallang_db.xml:tx_typo3forum_domain_model_forum_topic.readers',
 			'config' => [
 				'type' => 'select',


### PR DESCRIPTION
 This patch improves the TCA of Forum, Post and Topic by adding exclude-
properties to several columns and adds columns so they can be edited in
the TYPO3 backend.

Requires https://github.com/mittwald/typo3_forum/pull/284 to be merged
first in order to avoid conflicts.