### PR TITLE
Improve new Topic form

### DIFF
--- a/Classes/ViewHelpers/Bootstrap/Form/RowViewHelper.php
+++ b/Classes/ViewHelpers/Bootstrap/Form/RowViewHelper.php
@@ -23,6 +23,7 @@ namespace Mittwald\Typo3Forum\ViewHelpers\Bootstrap\Form;
  *  This copyright notice MUST APPEAR in all copies of the script!      *
  *                                                                      */
 
+use TYPO3\CMS\Extbase\Utility\LocalizationUtility;
 use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractTagBasedViewHelper;
 
 /**
@@ -48,15 +49,17 @@ class RowViewHelper extends AbstractTagBasedViewHelper {
 		parent::initializeArguments();
 		$this->registerArgument('llLabel', 'string', 'Locallang key for label.', FALSE, '');
 		$this->registerArgument('label', 'string', 'Hardcoded label (better to use llLabel instead).', FALSE, '');
+		$this->registerArgument('labelFor', 'string', 'ID of the input to be used in label-for attribute', FALSE, '');
 		$this->registerArgument('error', 'string', 'Error property path.', FALSE);
 		$this->registerArgument('errorLLPrefix', 'string', 'Error label locallang prefix.', FALSE);
 	}
 
 	public function render() {
 		$class = 'control-group';
+		$errorContent = '';
 
 		if ($this->arguments['llLabel']) {
-			$label = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($this->arguments['llLabel'], 'typo3_forum');
+			$label = LocalizationUtility::translate($this->arguments['llLabel'], 'typo3_forum');
 		} else {
 			$label = $this->arguments['label'];
 		}
@@ -69,23 +72,19 @@ class RowViewHelper extends AbstractTagBasedViewHelper {
 			foreach ($propertyPath as $currentPropertyName) {
 				$errors = array_merge($errors,$this->getErrorsForProperty($currentPropertyName, $results));
             }
-			if (count($errors) > 0) {
+			if (!empty($errors)) {
 				$class .= ' error';
-				$errorContent = '';
 				foreach ($errors as $error) {
-					$errorText = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate($this->arguments['errorLLPrefix'] . '_' . $error->getCode(),
-					                                                        'typo3_forum');
+					$errorText = LocalizationUtility::translate($this->arguments['errorLLPrefix'] . '_' . $error->getCode(), 'typo3_forum');
 					if (!$errorText) {
 						$errorText = 'TRANSLATE: ' . $this->arguments['errorLLPrefix'] . '_' . $error->getCode();
 					}
-					$errorContent .= '<p class="help-block">' . $errorText . '</p>';
+					$errorContent .= '<p class="invalid-feedback help-block">' . $errorText . '</p>';
 				}
 			}
-		} else {
-			$errorText = '';
 		}
 
-		$label   = '<label>' . $label . '</label>';
+		$label = '<label' . ($this->arguments['labelFor'] ? ' for="' . $this->arguments['labelFor'] . '"' : '') . '>' . $label . '</label>';
 		$content = '<div>' . $this->renderChildren() . $errorContent . '</div>';
 
 		$this->tag->addAttribute('class', $class);

--- a/Resources/Private/Partials/Bootstrap/FormErrors.html
+++ b/Resources/Private/Partials/Bootstrap/FormErrors.html
@@ -1,8 +1,8 @@
 
 <f:form.validationResults>
 	<f:if condition="{validationResults.flattenedErrors}">
-		<div class="alert alert-error alert-block">
-			<h4>
+		<div class="alert alert-danger" role="alert">
+			<h4 class="alert-heading">
 				<f:translate key="Error_Form_Title" />
 			</h4>
 			<f:translate key="Error_Form_Body" />

--- a/Resources/Private/Templates/Bootstrap/Topic/New.html
+++ b/Resources/Private/Templates/Bootstrap/Topic/New.html
@@ -10,54 +10,52 @@
 	<f:form name="post" object="{post}" controller="Topic" action="create" id="topic" class="form-horizontal" enctype="multipart/form-data">
 		<div class="card">
 			<div class="card-header">
-			<h3><f:translate key="Topic_New"/></h3>
+				<h3><f:translate key="Topic_New"/></h3>
 			</div>
 
-		<div class="card-body">
-			<f:if condition="{currentUser.anonymous}">
-				<f:then>
+			<div class="card-body">
+				<f:if condition="{currentUser.anonymous}">
 					<div class="form-group">
-						<b:form.row llLabel="Post_New_Author" error="post.authorName" errorLLPrefix="Post_New_Error_Author">
-							<f:form.textfield property="authorName" class="form-control"/>
+						<b:form.row llLabel="Post_New_Author" labelFor="authorName" error="post.authorName" errorLLPrefix="Post_New_Error_Author">
+							<f:form.textfield property="authorName" id="authorName" class="form-control"/>
 						</b:form.row>
 					</div>
-				</f:then>
-			</f:if>
-			<div class="form-group">
-					<b:form.row llLabel="Topic_New_Subject" error="subject" errorLLPrefix="Topic_New_Error_Subject">
-						<f:form.textfield name="subject" value="{subject}" class="form-control"/>
+				</f:if>
+				<div class="form-group">
+					<b:form.row llLabel="Topic_New_Subject" labelFor="subject" error="subject" errorLLPrefix="Topic_New_Error_Subject">
+						<f:form.textfield name="subject" id="subject" value="{subject}" class="form-control" required="true"/>
 					</b:form.row>
-			</div>
-			<div class="form-group">
-				<b:form.row llLabel="Topic_New_Text" error="post.text" errorLLPrefix="Topic_New_Error_Post_Text">
-					<mmf:form.bbCodeEditor property="text" id="typo3forum_editor" rows="20" class="form-control"/>
-				</b:form.row>
-			</div>
-			<div class="form-group">
-				<b:form.row llLabel="Topic_New_Attachments">
-					<f:if condition="{post.attachments}">
-						<f:for each="{post.attachments}" as="attachment">
-							<div>
-								{attachment.filename},
-								<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
-							</div>
-						</f:for>
-					</f:if>
-					<f:form.upload name="attachments[0]"/>
-				</b:form.row>
-				<b:form.row llLabel="Topic_New_Subscribe">
-					<label class="form-check-label" for="<f:translate key="Topic_New_SubscribeMore"/>">
-						<f:form.checkbox name="subscribe" value="1"/>
+				</div>
+				<div class="form-group">
+					<b:form.row llLabel="Topic_New_Text" labelFor="typo3forum_editor" error="post.text" errorLLPrefix="Topic_New_Error_Post_Text">
+						<mmf:form.bbCodeEditor property="text" id="typo3forum_editor" rows="20" class="form-control"/>
+					</b:form.row>
+				</div>
+				<div class="form-group">
+					<b:form.row llLabel="Topic_New_Attachments" labelFor="attachment-upload">
+						<f:if condition="{post.attachments}">
+							<f:for each="{post.attachments}" as="attachment">
+								<div>
+									{attachment.filename},
+									<mmf:format.fileSize>{attachment.filesize}</mmf:format.fileSize>
+								</div>
+							</f:for>
+						</f:if>
+						<f:form.upload id="attachment-upload" name="attachments[0]"/>
+					</b:form.row>
+				</div>
+				<div class="form-group">
+					<b:form.row llLabel="Topic_New_Subscribe" labelFor="subscribe">
+						<f:form.checkbox name="subscribe" id="subscribe" value="1"/>
 						<f:translate key="Topic_New_SubscribeMore"/>
-					</label>
-				</b:form.row>
+					</b:form.row>
+				</div>
+				<div class="form-actions">
+					<f:form.hidden name="forum" value="{forum}"/>
+					<b:button primary="1" icon="back" controller="Forum" action="show" arguments="{forum: forum}" label="Button_Back"/>
+					<f:form.submit class="btn btn-primary ml-1" value="{f:translate(key:'Topic_New_Submit')}"/>
+				</div>
 			</div>
-			<div class="form-actions">
-				<f:form.hidden name="forum" value="{forum}"/>
-				<f:form.submit class="btn btn-primary" value="{f:translate(key:'Topic_New_Submit')}"/>
-				<b:button controller="Forum" action="show" arguments="{forum: forum}" label="Button_Back"/>
-			</div>
-		</div>
 		</div>
 	</f:form>
 </f:section>

--- a/Resources/Private/Templates/Standard/Topic/New.html
+++ b/Resources/Private/Templates/Standard/Topic/New.html
@@ -9,19 +9,17 @@
 		<fieldset>
 			<legend>Create a new topic</legend>
 			<f:if condition="{currentUser.anonymous}">
-				<f:then>
-					<b:form.row llLabel="Post_New_Author" error="post.authorName" errorLLPrefix="Post_New_Error_Author">
-						<f:form.textfield property="authorName" />
-					</b:form.row>
-				</f:then>
+				<b:form.row llLabel="Post_New_Author" labelFor="authorName" error="post.authorName" errorLLPrefix="Post_New_Error_Author">
+					<f:form.textfield property="authorName" id="authorName"/>
+				</b:form.row>
 			</f:if>
-			<b:form.row llLabel="Topic_New_Subject" error="subject" errorLLPrefix="Topic_New_Error_Subject">
-				<f:form.textfield name="subject" value="{subject}" />
+			<b:form.row llLabel="Topic_New_Subject" labelFor="subject" error="subject" errorLLPrefix="Topic_New_Error_Subject">
+				<f:form.textfield name="subject" id="subject" value="{subject}" required="true" />
 			</b:form.row>
-			<b:form.row llLabel="Topic_New_Text" error="post.text" errorLLPrefix="Topic_New_Error_Post_Text">
+			<b:form.row llLabel="Topic_New_Text" labelFor="typo3forum_editor" error="post.text" errorLLPrefix="Topic_New_Error_Post_Text">
 				<mmf:form.bbCodeEditor property="text" id="typo3forum_editor" rows="20" cols="40" />
 			</b:form.row>
-			<b:form.row llLabel="Topic_New_Attachments">
+			<b:form.row llLabel="Topic_New_Attachments" labelFor="attachment-upload">
 				<f:if condition="{post.attachments}">
 					<f:for each="{post.attachments}" as="attachment">
 						<div>
@@ -30,18 +28,16 @@
 						</div>
 					</f:for>
 				</f:if>
-				<f:form.upload name="attachments[0]"/>
+				<f:form.upload id="attachment-upload" name="attachments[0]"/>
 			</b:form.row>
-			<b:form.row llLabel="Topic_New_Subscribe">
-				<label >
-					<f:form.checkbox name="subscribe" value="1"/>
-					<f:translate key="Topic_New_SubscribeMore"/>
-				</label>
+			<b:form.row llLabel="Topic_New_Subscribe" labelFor="subscribe">
+				<f:form.checkbox name="subscribe" id="subscribe" value="1"/>
+				<f:translate key="Topic_New_SubscribeMore"/>
 			</b:form.row>
-			<div >
+			<div>
 				<f:form.hidden name="forum" value="{forum}"/>
+				<b:button primary="1" icon="back"controller="Forum" action="show" arguments="{forum: forum}" label="Button_Back"/>
 				<f:form.submit value="{f:translate(key:'Topic_New_Submit')}"/>
-				<b:button controller="Forum" action="show" arguments="{forum: forum}" label="Button_Back"/>
 			</div>
 		</fieldset>
 	</f:form>


### PR DESCRIPTION
This patch improves the new Topic form by:

* adding and using a new attribute "labelFor" the the RowViewHelper
  allowing to connect labels with their according inputs
* styling the error text for an input and the general form errors on
  form submission using bootstrap styles
* marking required inputs as such in order to prevent empty submissions
* aligning order and button-style for the back-button with other
  back-buttons in the extension
* separating the attachments and subscription form-group in bootstrap
  template