### PR TITLE
Fix TCA display of attachment

### DIFF
--- a/Configuration/TCA/tx_typo3forum_domain_model_forum_attachment.php
+++ b/Configuration/TCA/tx_typo3forum_domain_model_forum_attachment.php
@@ -73,6 +73,7 @@ return [
 				'type' => 'group',
 				'internal_type' => 'file',
 				'uploadfolder' => 'uploads/tx_typo3forum/attachments/',
+				'size' => 1,
 				'minitems' => 1,
 				'maxitems' => 1,
 				'allowed' => '*',


### PR DESCRIPTION
An attachment allows only one file. This patch changes TCA to display
the attachment in BE as a single-file selector instead of multiple.